### PR TITLE
fix: multiline pasting with border enabled

### DIFF
--- a/src/components/import-popup.tsx
+++ b/src/components/import-popup.tsx
@@ -17,7 +17,7 @@ const getDeathnotices = (data: string): DeathNoticeT[] => {
 	if (!delim) return result;
 
 	for (const row of rows) {
-		const values = row.split(delim);
+		const values = row.trim().split(delim);
 
 		if (values.length !== 15) continue;
 		if (values[0] === '' || values[1] === '' || values[2] === '' || values[3] === '') continue;


### PR DESCRIPTION
When importing killfeed data from clipboard with multiple lines that have red border set to true, results in only the last killfeed displaying the border.

e.g.
ct,donk,t,sjuush,,,ak47,true,false,false,false,false,false,false,true
ct,donk,t,NertZ,,,ak47,true,false,false,false,false,false,false,true
ct,donk,t,degster,,,ak47,true,false,false,false,false,false,false,true
ct,donk,t,kyxsan,,,ak47,false,false,false,false,false,false,false,true
ct,donk,t,TeSeS,,,ak47,false,false,false,false,false,false,false,true

![image](https://github.com/user-attachments/assets/a104b069-d9e9-43d5-ad22-05fa34dc1de6)

This is due to the newline character `\n` trailing the line and thus failing the check `'true\n' === 'true'`

This fix simply trims the line removing the newline char.

![image](https://github.com/user-attachments/assets/44ef7b1c-7d5c-41f8-9ea8-a96539a26bb2)
